### PR TITLE
Fix "How To Use" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Website for [service-fabric-pub-sub.socreate.it](http://service-fabric-pub-sub.socreate.it)
+# Website for [service-fabric-pub-sub.socreate.it](https://service-fabric-pub-sub.socreate.it)
 
-This is the source for the [service-fabric-pub-sub.socreate.it](http://service-fabric-pub-sub.socreate.it) website.
+This is the source for the [service-fabric-pub-sub.socreate.it](https://service-fabric-pub-sub.socreate.it) website.

--- a/docs/404.html
+++ b/docs/404.html
@@ -17,16 +17,16 @@
   <meta name="twitter:site" content="@socreate">
   <meta name="twitter:creator" content="@socreate">
   <meta name="twitter:image" content="@socreate">
-  <meta name="twitter:image:alt" content="http://service-fabric-pub-sub.socreate.it/assets/social/service-fabric-pub-sub-twitter.jpg">
+  <meta name="twitter:image:alt" content="https://service-fabric-pub-sub.socreate.it/assets/social/service-fabric-pub-sub-twitter.jpg">
   <meta property="fb:app_id" content="1384123038328081">
-  <meta property="og:url" content="http://service-fabric-pub-sub.socreate.it">
+  <meta property="og:url" content="https://service-fabric-pub-sub.socreate.it">
   <meta property="og:title" content="Microsoft Service Fabric Pub/Sub">
   <meta
     property="og:description"
     content="
       Do you want to create an Event Driven Architecture while using Azure Service Fabric? Do you need to reliably broadcast messages
       between Actors and Services? This code will help you do that. It supports both Actors and Services as publishers and subscribers.">
-  <meta property="og:image" content="http://service-fabric-pub-sub.socreate.it/assets/social/service-fabric-pub-sub-facebook.png">
+  <meta property="og:image" content="https://service-fabric-pub-sub.socreate.it/assets/social/service-fabric-pub-sub-facebook.png">
   <meta property="og:site_name" content="Microsoft Service Fabric Pub/Sub Documentation">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 <link rel="stylesheet" href="styles.b4d8c8fadbf3b7c3e11c.css"></head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,16 +17,16 @@
   <meta name="twitter:site" content="@socreate">
   <meta name="twitter:creator" content="@socreate">
   <meta name="twitter:image" content="@socreate">
-  <meta name="twitter:image:alt" content="http://service-fabric-pub-sub.socreate.it/assets/social/service-fabric-pub-sub-twitter.jpg">
+  <meta name="twitter:image:alt" content="https://service-fabric-pub-sub.socreate.it/assets/social/service-fabric-pub-sub-twitter.jpg">
   <meta property="fb:app_id" content="1384123038328081">
-  <meta property="og:url" content="http://service-fabric-pub-sub.socreate.it">
+  <meta property="og:url" content="https://service-fabric-pub-sub.socreate.it">
   <meta property="og:title" content="Microsoft Service Fabric Pub/Sub">
   <meta
     property="og:description"
     content="
       Do you want to create an Event Driven Architecture while using Azure Service Fabric? Do you need to reliably broadcast messages
       between Actors and Services? This code will help you do that. It supports both Actors and Services as publishers and subscribers.">
-  <meta property="og:image" content="http://service-fabric-pub-sub.socreate.it/assets/social/service-fabric-pub-sub-facebook.png">
+  <meta property="og:image" content="https://service-fabric-pub-sub.socreate.it/assets/social/service-fabric-pub-sub-facebook.png">
   <meta property="og:site_name" content="Microsoft Service Fabric Pub/Sub Documentation">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 <link rel="stylesheet" href="styles.b4d8c8fadbf3b7c3e11c.css"></head>

--- a/src/app/docs/getting-started/introduction/introduction.component.html
+++ b/src/app/docs/getting-started/introduction/introduction.component.html
@@ -5,7 +5,7 @@
   pattern to implement reliable asynchronous messaging between services using Service Remoting V2.
 </p>
 <img
-  src="http://service-fabric-pub-sub.socreate.it/assets/charts/pub-sub-diagram.svg"
+  src="https://service-fabric-pub-sub.socreate.it/assets/charts/pub-sub-diagram.svg"
   alt="
     Publishers can be reliable actors or services using an intermediate broker stateful service to broadcast to reliable
     actor or service subscribers"

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -12,33 +12,23 @@
   <em class="subTitle__note">
       You may also be interested in
       <a
-        href="http://service-fabric-distributed-cache.socreate.it"
+        href="https://service-fabric-distributed-cache.socreate.it"
         class="subTitle__link">Service Fabric Distributed Cache</a>
       and
       <a
-        href="http://service-fabric-data-protection.socreate.it"
+        href="https://service-fabric-data-protection.socreate.it"
         class="subTitle__link">Service Fabric Data Protection</a>
     </em>
 </h4>
 <img
-  src="http://service-fabric-pub-sub.socreate.it/assets/charts/pub-sub-diagram.svg"
+  src="https://service-fabric-pub-sub.socreate.it/assets/charts/pub-sub-diagram.svg"
   alt="
     Publishers can be reliable actors or services using an intermediate broker stateful service to broadcast to reliable
     actor or service subscribers"
   style="border: 0; margin: 1em 0 2em" />
 <ul class="highlights">
-    <li class="highlight">
-    <a routerLink="/docs" class="highlight__link">
-      <span class="highlight__label">
-        Set up Pub/Sub
-      </span>
-      <svg class="highlight__icon" viewBox="0 0 24 24">
-        <path d="M12 2c5.514 0 10 4.486 10 10s-4.486 10-10 10-10-4.486-10-10 4.486-10 10-10zm0-2c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm1.25 17c0 .69-.559 1.25-1.25 1.25-.689 0-1.25-.56-1.25-1.25s.561-1.25 1.25-1.25c.691 0 1.25.56 1.25 1.25zm1.393-9.998c-.608-.616-1.515-.955-2.551-.955-2.18 0-3.59 1.55-3.59 3.95h2.011c0-1.486.829-2.013 1.538-2.013.634 0 1.307.421 1.364 1.226.062.847-.39 1.277-.962 1.821-1.412 1.343-1.438 1.993-1.432 3.468h2.005c-.013-.664.03-1.203.935-2.178.677-.73 1.519-1.638 1.536-3.022.011-.924-.284-1.719-.854-2.297z"/>
-      </svg>
-    </a>
-  </li>
   <li class="highlight">
-    <a routerLink="/docs/how-to/setup-pubsub-broker" class="highlight__link">
+    <a routerLink="/docs" class="highlight__link">
       <span class="highlight__label">
         How To Use
       </span>

--- a/src/index.html
+++ b/src/index.html
@@ -18,16 +18,16 @@
   <meta name="twitter:site" content="@socreate">
   <meta name="twitter:creator" content="@socreate">
   <meta name="twitter:image" content="@socreate">
-  <meta name="twitter:image:alt" content="http://service-fabric-pub-sub.socreate.it/assets/social/service-fabric-pub-sub-twitter.jpg">
+  <meta name="twitter:image:alt" content="https://service-fabric-pub-sub.socreate.it/assets/social/service-fabric-pub-sub-twitter.jpg">
   <meta property="fb:app_id" content="1384123038328081">
-  <meta property="og:url" content="http://service-fabric-pub-sub.socreate.it">
+  <meta property="og:url" content="https://service-fabric-pub-sub.socreate.it">
   <meta property="og:title" content="Microsoft Service Fabric Pub/Sub">
   <meta
     property="og:description"
     content="
       Do you want to create an Event Driven Architecture while using Azure Service Fabric? Do you need to reliably broadcast messages
       between Actors and Services? This code will help you do that. It supports both Actors and Services as publishers and subscribers.">
-  <meta property="og:image" content="http://service-fabric-pub-sub.socreate.it/assets/social/service-fabric-pub-sub-facebook.png">
+  <meta property="og:image" content="https://service-fabric-pub-sub.socreate.it/assets/social/service-fabric-pub-sub-facebook.png">
   <meta property="og:site_name" content="Microsoft Service Fabric Pub/Sub Documentation">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>


### PR DESCRIPTION
The "How To Use" link on the home page was broken and it wasn't clear which page the two links should go to, so I just removed the "Getting Started" button and pointed the "How To Use" button to the introduction page.

Also changed http to https.